### PR TITLE
Fix for allowing update statements to set a column to null (DBNull)

### DIFF
--- a/Source/EntityFramework.Extended/Extensions/BatchExtensions.cs
+++ b/Source/EntityFramework.Extended/Extensions/BatchExtensions.cs
@@ -466,7 +466,7 @@ namespace EntityFramework.Extensions
 
                     var parameter = updateCommand.CreateParameter();
                     parameter.ParameterName = parameterName;
-                    parameter.Value = value;
+                    parameter.Value = value ?? System.DBNull.Value;;
                     updateCommand.Parameters.Add(parameter);
 
                     sqlBuilder.AppendFormat("{0} = @{1}", columnName, parameterName);


### PR DESCRIPTION
Without fix it complains that parameter has no value.
