### PR TITLE
Handle inheritance when determining mapping

### DIFF
--- a/Source/EntityFramework.Extended/Mapping/MetadataMappingProvider.cs
+++ b/Source/EntityFramework.Extended/Mapping/MetadataMappingProvider.cs
@@ -64,9 +64,9 @@ namespace EntityFramework.Mapping
                     .Single(s => s.EntitySet == entitySet);
 
             // Find the storage entity set (table) that the entity is mapped
-            var mappingFragment = mapping
-                .EntityTypeMappings.Single()
-                .Fragments.Single();
+            var mappingFragment =
+                (mapping.EntityTypeMappings.SingleOrDefault(a => a.IsHierarchyMapping) ?? mapping.EntityTypeMappings.Single())
+                    .Fragments.Single();
 
             entityMap.ModelType = entityType;
             entityMap.ModelSet = entitySet;

--- a/Source/Samples/net45/Tracker.SqlServer.CodeFirst/Entities/TaskChild.cs
+++ b/Source/Samples/net45/Tracker.SqlServer.CodeFirst/Entities/TaskChild.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tracker.SqlServer.CodeFirst.Entities
+{
+    public partial class TaskChild : Task
+    {
+    }
+}

--- a/Source/Samples/net45/Tracker.SqlServer.CodeFirst/Tracker.SqlServer.CodeFirst.csproj
+++ b/Source/Samples/net45/Tracker.SqlServer.CodeFirst/Tracker.SqlServer.CodeFirst.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Entities\Task.Generated.cs">
       <DependentUpon>Task.cs</DependentUpon>
     </Compile>
+    <Compile Include="Entities\TaskChild.cs" />
     <Compile Include="Entities\TaskExtended.cs" />
     <Compile Include="Entities\TaskExtended.Generated.cs">
       <DependentUpon>TaskExtended.cs</DependentUpon>

--- a/Source/Samples/net45/Tracker.SqlServer.Test/MappingObjectContext.cs
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/MappingObjectContext.cs
@@ -40,6 +40,20 @@ namespace Tracker.SqlServer.Test
             Assert.AreEqual("[dbo].[Audit]", map.TableName);
         }
 
+
+        [Test]
+        public void GetInheritedEntityMapAuditData()
+        {
+            var db = new TrackerContext();
+            var resolver = new MetadataMappingProvider();
+
+            var map = resolver.GetEntityMap(typeof(CodeFirst.Entities.Task), db);
+
+            //var map = db.Audits.ToObjectQuery().GetEntityMap<AuditData>();
+
+            Assert.AreEqual("[dbo].[Task]", map.TableName);
+        }
+
     }
 
 


### PR DESCRIPTION
For any object hierarchy the Single() call failed as there is more than one. I created a test case that demonstrates this this issue and confirms both the existing and modified case works.
