### PR TITLE
fix for #123

### DIFF
--- a/Source/EntityFramework.Extended/Audit/AuditLogger.cs
+++ b/Source/EntityFramework.Extended/Audit/AuditLogger.cs
@@ -188,7 +188,6 @@ namespace EntityFramework.Audit
             WriteRelationships(state);
 
             return true;
-
         }
 
         private void WriteKeys(AuditEntryState state)
@@ -360,13 +359,14 @@ namespace EntityFramework.Audit
                     auditProperty.IsRelationship = true;
                     auditProperty.ForeignKey = GetForeignKey(navigationProperty);
 
-                    object currentValue;
+                    object currentValue = null;
 
                     if (isLoaded)
                     {
                         // get value directly from instance to save db call
                         object valueInstance = accessor.GetValue(state.Entity);
-                        currentValue = displayMember.GetValue(valueInstance);
+                        if(valueInstance != null)
+                            currentValue = displayMember.GetValue(valueInstance);
                     }
                     else
                     {


### PR DESCRIPTION
Auditlogger gives nullreference exception when trying to lo a relationship that is already loaded, in case the value of the relationship is null
