### PR TITLE
Fix for #133. Compatibility for custom `IDbSet<>`

### DIFF
--- a/Source/EntityFramework.Extended/Extensions/ObjectQueryExtensions.cs
+++ b/Source/EntityFramework.Extended/Extensions/ObjectQueryExtensions.cs
@@ -28,8 +28,18 @@ namespace EntityFramework.Extensions
 
           // next try case to DbQuery
           var dbQuery = query as DbQuery<TEntity>;
+
+          // next look for an ObjectQuery property
           if (dbQuery == null)
-              return null;
+          {
+              var queryType = query.GetType();
+              var prop = queryType.GetProperties().FirstOrDefault(p => p.PropertyType == typeof(ObjectQuery));
+
+              if (prop == null)
+                  return null;
+
+              return (ObjectQuery<TEntity>)prop.GetValue(query);
+          }
 
           // access internal property InternalQuery
           dynamic dbQueryProxy = new DynamicProxy(dbQuery);


### PR DESCRIPTION
Fix for #133. Adds compatibility for custom `IDbSet<>` implementations
by looking for an `ObjectQuery` property after trying the existing
checks
