### PR TITLE
Changed the internally used System.Linq.Dynamic namespace

### DIFF
--- a/Source/EntityFramework.Extended/Batch/SqlServerBatchRunner.cs
+++ b/Source/EntityFramework.Extended/Batch/SqlServerBatchRunner.cs
@@ -4,7 +4,7 @@ using System.Data.Common;
 using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Core.Objects;
 using System.Linq;
-using System.Linq.Dynamic;
+using EntityFramework.DynamicLinq;
 using System.Linq.Expressions;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/Source/EntityFramework.Extended/Dynamic/DynamicQueryable.cs
+++ b/Source/EntityFramework.Extended/Dynamic/DynamicQueryable.cs
@@ -11,7 +11,11 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading;
 
-namespace System.Linq.Dynamic
+//Given the strongname debate, it's unlikely that the nuget System.Linq.Dynamic will be strong named, and as this library is, we can't
+//use that nuget package.  Because of this, prefixing the normal System.Linq.Dynamic Namespace avoids conflicts with 
+//the package in projects that use both EF.Extended and System.Linq.Dynamic.  If/When this is no longer strong named, or If/When 
+//System.Dynamic.Linq nuget package IS strong named, then this class could be removed, and would just use nuget.
+namespace EntityFramework.DynamicLinq //System.Linq.Dynamic
 {
     public static class DynamicQueryable
     {


### PR DESCRIPTION
Changed the internally used System.Linq.Dynamic namespace so it is project specific, to avoid interfering with references in other projects.
Means that we can reference both this and System.Linq.Dynamic in the same project.  Fixes issue #114 

the options were

-reference the nuget for System.Linq.Dynamic (which can't be done thanks to strong naming hell)
-change this library to not be strong named (which will result in gnashing of teeth from those who are currently using strong naming) 
-do as this checkin does, and change the namespace so it's project prefixed and won't collide with other libraries.

Went with the last option as it seems path of least resistance.  Only breaking issue could be users who have decided to reference this library, and then gone on to use the dynamic linq contained package will have to update their own referenecs.  Ideally they should instead be referencing the nuget package, but irrespective, they definitely shouldn't be referencing this package for the purpose of using dynamic linq, and this chagne will not cause unexpected behaviour, it will cause a very obvious compile error.
