### PR TITLE
Adding support for Interception when using Future Queries

### DIFF
--- a/Source/EntityFramework.Extended.Test/EntityFramework.Extended.Test.net40.csproj
+++ b/Source/EntityFramework.Extended.Test/EntityFramework.Extended.Test.net40.csproj
@@ -108,6 +108,9 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Source/EntityFramework.Extended/Future/FutureRunner.cs
+++ b/Source/EntityFramework.Extended/Future/FutureRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Core.Objects;
+using System.Data.Entity.Infrastructure.Interception;
 using System.Text;
 using EntityFramework.Reflection;
 
@@ -32,7 +33,7 @@ namespace EntityFramework.Future
             try
             {
                 using (var command = CreateFutureCommand(context, futureQueries))
-                using (var reader = command.ExecuteReader())
+                using (var reader = DbInterception.Dispatch.Command.Reader(command, new DbCommandInterceptionContext(context.InterceptionContext)))
                 {
                     foreach (var futureQuery in futureQueries)
                     {

--- a/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
+++ b/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
@@ -52,15 +52,11 @@ namespace Tracker.SqlServer.Test
 
                 interceptor.Received().ScalarExecuting(
                   Arg.Any<DbCommand>(),
-                  Arg.Is<DbCommandInterceptionContext<object>>(
-                      ctx => ctx.DbContexts != null
-                          && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+                  Arg.Any<DbCommandInterceptionContext<object>>();
 
                 interceptor.Received().ScalarExecuted(
                     Arg.Any<DbCommand>(),
-                    Arg.Is<DbCommandInterceptionContext<object>>(
-                        ctx => ctx.DbContexts != null
-                            && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+                    Arg.Any<DbCommandInterceptionContext<object>>();
 
                 interceptor.DidNotReceive().NonQueryExecuting(
                     Arg.Any<DbCommand>(),

--- a/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
+++ b/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure.Interception;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using Tracker.SqlServer.CodeFirst;
+using Xunit;
+using EntityFramework.Extensions;
+using EntityFramework.Future;
+using System.Data.Common;
+
+namespace Tracker.SqlServer.Test
+{
+    public class InterceptorTest
+    {
+        [Fact]
+        public void TestInterception()
+        {
+            using(var db = new TrackerContext())
+            {
+                var interceptor = Substitute.For<IDbCommandInterceptor>();
+                
+                DbInterception.Add(interceptor);
+
+                // run a future query
+                var q = db.Tasks.Where(p => p.PriorityId == 2)
+                    .OrderByDescending(t => t.CreatedDate);
+                
+                var q1 = q.FutureCount();                
+                var q2 = q.Skip(0).Take(10).Future();
+                
+                var tasks = q2.ToList();
+                int total = q1.Value;
+
+                // assert that all the appropriate interceptor methods were called
+                interceptor.Received().ReaderExecuting(
+                    Arg.Any<DbCommand>(), 
+                    Arg.Is<DbCommandInterceptionContext<DbDataReader>>(
+                        ctx => ctx.DbContexts != null                            
+                            && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+
+                interceptor.Received().ReaderExecuted(
+                    Arg.Any<DbCommand>(), 
+                    Arg.Is<DbCommandInterceptionContext<DbDataReader>>(
+                        ctx => ctx.DbContexts != null
+                            && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+
+                interceptor.Received().ScalarExecuting(
+                  Arg.Any<DbCommand>(),
+                  Arg.Is<DbCommandInterceptionContext<object>>(
+                      ctx => ctx.DbContexts != null
+                          && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+
+                interceptor.Received().ScalarExecuted(
+                    Arg.Any<DbCommand>(),
+                    Arg.Is<DbCommandInterceptionContext<object>>(
+                        ctx => ctx.DbContexts != null
+                            && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+
+                interceptor.DidNotReceive().NonQueryExecuting(
+                    Arg.Any<DbCommand>(),
+                    Arg.Any<DbCommandInterceptionContext<int>>());
+
+                interceptor.DidNotReceive().NonQueryExecuted(
+                    Arg.Any<DbCommand>(),
+                    Arg.Any<DbCommandInterceptionContext<int>>());
+                              
+                DbInterception.Remove(interceptor);
+
+            }
+        }
+    }
+}

--- a/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
+++ b/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
@@ -50,11 +50,11 @@ namespace Tracker.SqlServer.Test
                         ctx => ctx.DbContexts != null
                             && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
 
-                interceptor.Received().ScalarExecuting(
+                interceptor.DidNotReceive().ScalarExecuting(
                   Arg.Any<DbCommand>(),
                   Arg.Any<DbCommandInterceptionContext<object>>());
 
-                interceptor.Received().ScalarExecuted(
+                interceptor.DidNotReceive().ScalarExecuted(
                     Arg.Any<DbCommand>(),
                     Arg.Any<DbCommandInterceptionContext<object>>());
 

--- a/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
+++ b/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
@@ -13,6 +13,9 @@ using System.Data.Common;
 
 namespace Tracker.SqlServer.Test
 {
+    /// <summary>
+    /// Tests interceptors with future queries
+    /// </summary>
     public class InterceptorTest
     {
         [Fact]
@@ -68,7 +71,6 @@ namespace Tracker.SqlServer.Test
                     Arg.Any<DbCommandInterceptionContext<int>>());
                               
                 DbInterception.Remove(interceptor);
-
             }
         }
     }

--- a/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
+++ b/Source/Samples/net40/Tracker.SqlServer.Test/InterceptorTest.cs
@@ -52,11 +52,11 @@ namespace Tracker.SqlServer.Test
 
                 interceptor.Received().ScalarExecuting(
                   Arg.Any<DbCommand>(),
-                  Arg.Any<DbCommandInterceptionContext<object>>();
+                  Arg.Any<DbCommandInterceptionContext<object>>());
 
                 interceptor.Received().ScalarExecuted(
                     Arg.Any<DbCommand>(),
-                    Arg.Any<DbCommandInterceptionContext<object>>();
+                    Arg.Any<DbCommandInterceptionContext<object>>());
 
                 interceptor.DidNotReceive().NonQueryExecuting(
                     Arg.Any<DbCommand>(),

--- a/Source/Samples/net40/Tracker.SqlServer.Test/Tracker.SqlServer.Test.net40.csproj
+++ b/Source/Samples/net40/Tracker.SqlServer.Test/Tracker.SqlServer.Test.net40.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -15,6 +16,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>4c6f27b9</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -58,6 +60,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.7\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NSubstitute">
+      <HintPath>..\..\..\packages\NSubstitute.1.8.1.0\lib\net40\NSubstitute.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -85,6 +90,7 @@
     <Compile Include="ExtensionTest.cs" />
     <Compile Include="FutureDbContext.cs" />
     <Compile Include="FutureObjectContext.cs" />
+    <Compile Include="InterceptorTest.cs" />
     <Compile Include="MappingObjectContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlTests.cs" />
@@ -113,7 +119,16 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Samples/net40/Tracker.SqlServer.Test/packages.config
+++ b/Source/Samples/net40/Tracker.SqlServer.Test/packages.config
@@ -3,5 +3,7 @@
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="FluentAssertions" version="3.2.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.7" targetFramework="net45" />
+  <package id="NSubstitute" version="1.8.1.0" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net40" />
 </packages>

--- a/Source/Samples/net45/Tracker.SqlServer.Test/InterceptorTest.cs
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/InterceptorTest.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity.Infrastructure.Interception;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using Tracker.SqlServer.CodeFirst;
+using Xunit;
+using EntityFramework.Extensions;
+using EntityFramework.Future;
+using System.Data.Common;
+
+namespace Tracker.SqlServer.Test
+{
+    public class InterceptorTest
+    {
+        [Fact]
+        public void TestInterception()
+        {
+            using(var db = new TrackerContext())
+            {
+                var interceptor = Substitute.For<IDbCommandInterceptor>();
+                
+                DbInterception.Add(interceptor);
+
+                // run a future query
+                var q = db.Tasks.Where(p => p.PriorityId == 2)
+                    .OrderByDescending(t => t.CreatedDate);
+                
+                var q1 = q.FutureCount();                
+                var q2 = q.Skip(0).Take(10).Future();
+                
+                var tasks = q2.ToList();
+                int total = q1.Value;
+
+                // assert that all the appropriate interceptor methods were called
+                interceptor.Received().ReaderExecuting(
+                    Arg.Any<DbCommand>(), 
+                    Arg.Is<DbCommandInterceptionContext<DbDataReader>>(
+                        ctx => ctx.DbContexts != null                            
+                            && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+
+                interceptor.Received().ReaderExecuted(
+                    Arg.Any<DbCommand>(), 
+                    Arg.Is<DbCommandInterceptionContext<DbDataReader>>(
+                        ctx => ctx.DbContexts != null
+                            && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+
+                interceptor.Received().ScalarExecuting(
+                  Arg.Any<DbCommand>(),
+                  Arg.Is<DbCommandInterceptionContext<object>>(
+                      ctx => ctx.DbContexts != null
+                          && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+
+                interceptor.Received().ScalarExecuted(
+                    Arg.Any<DbCommand>(),
+                    Arg.Is<DbCommandInterceptionContext<object>>(
+                        ctx => ctx.DbContexts != null
+                            && ctx.DbContexts.Count(x => x is TrackerContext) == 1));
+
+                interceptor.DidNotReceive().NonQueryExecuting(
+                    Arg.Any<DbCommand>(),
+                    Arg.Any<DbCommandInterceptionContext<int>>());
+
+                interceptor.DidNotReceive().NonQueryExecuted(
+                    Arg.Any<DbCommand>(),
+                    Arg.Any<DbCommandInterceptionContext<int>>());
+                              
+                DbInterception.Remove(interceptor);
+
+            }
+        }
+    }
+}

--- a/Source/Samples/net45/Tracker.SqlServer.Test/Tracker.SqlServer.Test.csproj
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/Tracker.SqlServer.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -15,6 +16,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>bb8ca2e0</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -62,6 +64,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.7\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="NSubstitute">
+      <HintPath>..\..\..\packages\NSubstitute.1.8.1.0\lib\net45\NSubstitute.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -89,6 +94,7 @@
     <Compile Include="ExtensionTest.cs" />
     <Compile Include="FutureDbContext.cs" />
     <Compile Include="FutureObjectContext.cs" />
+    <Compile Include="InterceptorTest.cs" />
     <Compile Include="MappingObjectContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SqlTests.cs" />
@@ -117,7 +123,16 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\xunit.runner.visualstudio.2.0.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Samples/net45/Tracker.SqlServer.Test/packages.config
+++ b/Source/Samples/net45/Tracker.SqlServer.Test/packages.config
@@ -3,5 +3,7 @@
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
   <package id="FluentAssertions" version="3.1.229" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="NSubstitute" version="1.8.1.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The original code circumvented  interceptors when running Future Queries causing issues with certain logging and profiling tools. This work adds full support for interception.
