### PR TITLE
- fix Append method call

### DIFF
--- a/Source/EntityFramework.Extended/Batch/MySqlBatchRunner.cs
+++ b/Source/EntityFramework.Extended/Batch/MySqlBatchRunner.cs
@@ -230,7 +230,7 @@ namespace EntityFramework.Batch
 
                 sqlBuilder.Append("UPDATE ");
                 sqlBuilder.Append(entityMap.TableName);
-                sqlBuilder.AppendFormat(" AS j0 INNER JOIN (", entityMap.TableName);
+                sqlBuilder.Append(" AS j0 INNER JOIN (");
                 sqlBuilder.AppendLine();
                 sqlBuilder.AppendLine(innerSelect);
                 sqlBuilder.Append(") AS j1 ON (");


### PR DESCRIPTION
Method Append format does not use entityMap.TableName parameter, so it's better to remove it.